### PR TITLE
added facet for bots to be able to sign trades on behalf of merchants…

### DIFF
--- a/contracts/globals/Errors.sol
+++ b/contracts/globals/Errors.sol
@@ -10,6 +10,7 @@ error ZeroAddress();
 error ZeroNumber();
 error InvalidChainId();
 error InvalidSigner();
+error InvalidBotSigner();
 error InvalidSignature();
 error SignatureExpired();
 error CrossChainUnsupported();

--- a/contracts/globals/OrderHelpers.sol
+++ b/contracts/globals/OrderHelpers.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../interfaces/IOrderSig.sol";
+import "../globals/Errors.sol";
+import "../libraries/Helpers.sol";
+
+abstract contract OrderHelpers {
+    modifier validSig(bytes calldata _sig) {
+        if (HelpersLib.compareBytes(_sig, HelpersLib.emptyBytes)) {
+            revert InvalidSignature();
+        }
+        _;
+    }
+
+    modifier sigNotExpired(uint256 _expiry) {
+        if (_expiry < block.timestamp) {
+            revert SignatureExpired();
+        }
+        _;
+    }
+
+    modifier onlyOrderMethod(
+        IOrderSig.OrderMethod _method,
+        IOrderSig.OrderMethod _expected
+    ) {
+        if (_method != _expected) {
+            revert IOrderSig.InvalidOrderMethodCall();
+        }
+        _;
+    }
+}

--- a/contracts/interfaces/IExchange.sol
+++ b/contracts/interfaces/IExchange.sol
@@ -5,12 +5,14 @@ import "./IExchangeManager.sol";
 import "./IExchangeView.sol";
 import "./IOrder.sol";
 import "./IOrderSig.sol";
+import "./IOrderBotSig.sol";
 import "./IAppeal.sol";
 
 
 abstract contract IExchange is
     IOrder,
     IOrderSig,
+    IOrderBotSig,
     IAppeal,
     IExchangeView,
     IExchangeManager

--- a/contracts/interfaces/IOrderBotSig.sol
+++ b/contracts/interfaces/IOrderBotSig.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../globals/Types.sol";
+import "./IOrderSig.sol";
+import "./IOrder.sol";
+
+/**
+ * @title   Order Bot Signature based
+ * @dev     Handles automated trading on behalf of merchant. Merchant can set and remove bot anytime.
+ * @notice  It is assumed only bot set by merchant will call the methods in this facet.
+ */
+
+abstract contract IOrderBotSig {
+    event BotSet(address merchant, address bot);
+    event BotRemoved(address merchant, address bot);
+    error NoBotSet();
+    function createOrderBot(
+        IOrder.CreateOrder calldata _order,
+        bytes calldata _traderSig,
+        bytes calldata _botSig
+    ) external virtual;
+
+    function acceptOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function payOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function releaseOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function cancelOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function appealOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function cancelAppealBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function confirmOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    ) external virtual;
+
+    function setBot(address _bot) external virtual;
+
+    function removeBot() external virtual;
+
+    function merchantBot(
+        address _merchant
+    ) external view virtual returns (address);
+}

--- a/contracts/libraries/LibBot.sol
+++ b/contracts/libraries/LibBot.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../libraries/LibData.sol";
+import "../interfaces/IOrderBotSig.sol";
+import "../globals/Errors.sol";
+
+library LibBot {
+    function _merchantBot(address _merchant) internal view returns (address) {
+        BotStore storage b = BotStorage.load();
+        if (b.merchantBot[_merchant] == address(0)) {
+            revert IOrderBotSig.NoBotSet();
+        }
+        return b.merchantBot[_merchant];
+    }
+
+    function _setBot(address _merchant, address _bot) internal {
+        BotStore storage b = BotStorage.load();
+        b.merchantBot[_merchant] = _bot;
+        emit IOrderBotSig.BotSet(_merchant, _bot);
+    }
+    function _removeBot(address _merchant) internal {
+        BotStore storage b = BotStorage.load();
+        address bot = b.merchantBot[_merchant];
+        if (bot == address(0)) {
+            revert IOrderBotSig.NoBotSet();
+        }
+        delete b.merchantBot[_merchant];
+        emit IOrderBotSig.BotRemoved(_merchant, bot);
+    }
+}

--- a/contracts/libraries/LibData.sol
+++ b/contracts/libraries/LibData.sol
@@ -38,3 +38,18 @@ library AppealStorage {
         }
     }
 }
+
+struct BotStore {
+    mapping(address => address) merchantBot; // merchant address -> bot trader
+}
+
+library BotStorage {
+    bytes32 constant BOT_STORAGE_POSITION = keccak256("iexchange.global.bot");
+
+    function load() internal pure returns (BotStore storage s) {
+        bytes32 position = BOT_STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+}

--- a/contracts/libraries/LibOrder.sol
+++ b/contracts/libraries/LibOrder.sol
@@ -350,4 +350,9 @@ library LibOrder {
     ) internal pure returns (uint256) {
         return HelpersLib.basisPoint(_amount, _token.orderFee);
     }
+
+    function _get(bytes32 _orderHash) internal view returns(IOrder.Order memory) {
+        OrderStore storage o = OrderStorage.load();
+        return o.orders[_orderHash];
+    }
 }

--- a/contracts/modules/OrderBotSig.sol
+++ b/contracts/modules/OrderBotSig.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../interfaces/IOrderSig.sol";
+import "../interfaces/IOrder.sol";
+import "../interfaces/IOrderBotSig.sol";
+import "../libraries/LibOrder.sol";
+import "../libraries/LibAppeal.sol";
+import "../libraries/LibSig.sol";
+import "../libraries/LibBot.sol";
+import "../globals/Errors.sol";
+import "../globals/OrderHelpers.sol";
+
+contract OrderBotSig is IOrderBotSig, OrderHelpers {
+    function createOrderBot(
+        IOrder.CreateOrder calldata _order,
+        bytes calldata _traderSig,
+        bytes calldata _botSig
+    ) external virtual override sigNotExpired(_order.expiry) validSig(_botSig) {
+        address bot = LibBot._merchantBot(_order.merchant);
+        OrderState state;
+        bytes32 _orderHash = LibSig._hashOrderEIP712(_order);
+        address trader = LibSig._signer(_orderHash, _traderSig);
+        if (_order.trader != trader) {
+            revert InvalidSigner();
+        }
+        address _signerBot = LibSig._signer(_orderHash, _botSig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        state = OrderState.accepted;
+
+        LibOrder._createOrder(_order, _orderHash, state);
+    }
+
+    function acceptOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.accept)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibOrder._acceptOrder(_method.orderHash, merchant);
+    }
+
+    function releaseOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.release)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibOrder._releaseOrder(_method.orderHash, merchant);
+    }
+
+    function cancelOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.cancel)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibOrder._cancelOrder(_method.orderHash, merchant);
+    }
+
+    function payOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.pay)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibOrder._payOrder(_method.orderHash, merchant);
+    }
+
+    function appealOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.appeal)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibAppeal._appeal(_method.orderHash, merchant);
+    }
+
+    function cancelAppealBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.cancelAppeal)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibAppeal._cancel(_method.orderHash, merchant);
+    }
+
+    function confirmOrderBot(
+        IOrderSig.OrderMethodPayload calldata _method,
+        bytes calldata _sig
+    )
+        external
+        virtual
+        override
+        sigNotExpired(_method.expiry)
+        validSig(_sig)
+        onlyOrderMethod(_method.method, IOrderSig.OrderMethod.confirm)
+    {
+        address merchant = LibOrder._get(_method.orderHash).merchant;
+        address bot = LibBot._merchantBot(merchant);
+        bytes32 _orderMethodHash = LibSig._hashOrderMethodEIP712(_method);
+        address _signerBot = LibSig._signer(_orderMethodHash, _sig);
+        if (bot != _signerBot) {
+            revert InvalidBotSigner();
+        }
+        LibOrder._confirmOrder(_method.orderHash, merchant);
+    }
+
+    function setBot(address _bot) external virtual override {
+        LibBot._setBot(msg.sender, _bot);
+    }
+
+    function removeBot() external virtual override {
+        LibBot._removeBot(msg.sender);
+    }
+
+    function merchantBot(
+        address _merchant
+    ) external view virtual override returns (address) {
+        return LibBot._merchantBot(_merchant);
+    }
+}

--- a/contracts/modules/OrderSig.sol
+++ b/contracts/modules/OrderSig.sol
@@ -6,28 +6,9 @@ import "../libraries/LibOrder.sol";
 import "../libraries/LibAppeal.sol";
 import "../libraries/LibSig.sol";
 import "../globals/Errors.sol";
-contract OrderSig is IOrderSig {
-    modifier validSig(bytes calldata _sig) {
-        if (HelpersLib.compareBytes(_sig, HelpersLib.emptyBytes)) {
-            revert InvalidSignature();
-        }
-        _;
-    }
+import "../globals/OrderHelpers.sol";
 
-    modifier sigNotExpired(uint256 _expiry) {
-        if (_expiry < block.timestamp) {
-            revert SignatureExpired();
-        }
-        _;
-    }
-
-    modifier onlyOrderMethod(OrderMethod _method, OrderMethod _expected) {
-        if (_method != _expected) {
-            revert InvalidOrderMethodCall();
-        }
-        _;
-    }
-
+contract OrderSig is IOrderSig, OrderHelpers {
     function createOrder(
         IOrder.CreateOrder calldata _order,
         bytes calldata _traderSig,


### PR DESCRIPTION
Added facet for bots to be able to sign trades on behalf of merchants this is necessary for automated p2p trading setup.

- Handles automated trading on behalf of merchant. Merchant can set and remove bot anytime.
- It is assumed only bot set by merchant will call the methods in this facet.